### PR TITLE
Fix available values for date_query_column

### DIFF
--- a/filter_post_using_date_query_column.php
+++ b/filter_post_using_date_query_column.php
@@ -32,7 +32,7 @@ function rest_api_add_post_date_query_column_param( $query_params ) {
 	$query_params['date_query_column'] = [
             'description' => __( 'The date query column.' ),
             'type'        => 'string',
-            'enum'        => ['post_date', 'post_date_gmt', 'post_modified', 'post_modified_gmt'],
+            'enum'        => ['date', 'date_gmt', 'modified', 'modified_gmt'],
         ];
     return $query_params;
 }


### PR DESCRIPTION
date_query_column would accept post_date, post_date_gmt, post_modified, post_modified_gmt instead of date, date_gmt, modified, modified_gmt. But in the query 'post_' is already added.

In this way the plugin works correctly (at least in my Wordpress 4.9.8).
